### PR TITLE
Include the full group resource in the all_groups output values

### DIFF
--- a/group/outputs.tf
+++ b/group/outputs.tf
@@ -22,9 +22,9 @@ output "registered_runners" {
 output "all_groups" {
   description = "Map of all created groups"
   value = merge([for slug, group in gitlab_group.group : {
-    (group.full_path)                     = { group_id = group.id }
-    "${group.full_path}/roles/owners"     = { group_id = gitlab_group.owner_role[slug].id }
-    "${group.full_path}/roles/developers" = { group_id = gitlab_group.developer_role[slug].id }
-    "${group.full_path}/roles/reporters"  = { group_id = gitlab_group.reporter_role[slug].id }
+    (group.full_path)                             = group
+    (gitlab_group.owner_role[slug].full_path)     = gitlab_group.owner_role[slug]
+    (gitlab_group.developer_role[slug].full_path) = gitlab_group.developer_role[slug]
+    (gitlab_group.reporter_role[slug].full_path)  = gitlab_group.reporter_role[slug]
   }]...)
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- include the full group resource in the output, so callers have more available data to use.
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, the caller is creating the groups so they are authorized to see all output values.
