### PR TITLE
Remove deprecated and mutually exclusive options

### DIFF
--- a/project/main.tf
+++ b/project/main.tf
@@ -13,7 +13,6 @@ locals {
   ])
 }
 
-# Gitlab Users 
 resource "gitlab_project" "project" {
   for_each = var.projects
   #required
@@ -43,7 +42,6 @@ resource "gitlab_project" "project" {
   ci_restrict_pipeline_cancellation_role           = each.value.ci_restrict_pipeline_cancellation_role
   ci_separated_caches                              = each.value.ci_separated_caches
   container_registry_access_level                  = each.value.container_registry_access_level
-  container_registry_enabled                       = each.value.container_registry_enabled
   default_branch                                   = each.value.default_branch
   description                                      = each.value.description
   emails_enabled                                   = each.value.emails_enabled
@@ -106,7 +104,6 @@ resource "gitlab_project" "project" {
   squash_commit_template                           = each.value.squash_commit_template
   squash_option                                    = each.value.squash_option
   suggestion_commit_message                        = each.value.suggestion_commit_message
-  template_name                                    = each.value.template_name
   template_project_id                              = each.value.template_project_id
   topics                                           = each.value.topics
   use_custom_template                              = each.value.use_custom_template

--- a/project/variables.tf
+++ b/project/variables.tf
@@ -44,7 +44,6 @@ variable "projects" {
       }
     ))
     container_registry_access_level                  = optional(string)
-    container_registry_enabled                       = optional(bool)
     default_branch                                   = optional(string, "main")
     description                                      = optional(string)
     emails_enabled                                   = optional(bool)
@@ -122,14 +121,12 @@ variable "projects" {
     squash_commit_template                  = optional(string)
     squash_option                           = optional(string)
     suggestion_commit_message               = optional(string)
-    template_name                           = optional(string)
     template_project_id                     = optional(number)
     topics                                  = optional(list(string))
     use_custom_template                     = optional(bool)
     visibility_level                        = optional(string)
     wiki_access_level                       = optional(string)
     wiki_enabled                            = optional(bool)
-
   }))
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- removes `template_name` option, as it's mutually exclusive with the preferred `template_project_id` option
- remove deprecated `container_registry_enabled` option, recommended to use just `container_registry_access_level`
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, removing options that have preferred methods to set the same.
