### PR TITLE
Switch normal use to using 'force_random_password'

### DIFF
--- a/user/main.tf
+++ b/user/main.tf
@@ -2,17 +2,21 @@
 resource "gitlab_user" "user" {
   for_each = var.users
 
-  name           = each.value.name
-  username       = each.value.username
-  email          = each.value.email
-  reset_password = each.value.reset_password
+  name                  = each.value.name
+  username              = each.value.username
+  email                 = each.value.email
+  reset_password        = each.value.reset_password
+  force_random_password = each.value.force_random_password
   # optional
   can_create_group  = each.value.can_create_group
   is_admin          = each.value.is_admin
   is_external       = each.value.is_external
   note              = each.value.note
-  password          = each.value.password
   projects_limit    = each.value.projects_limit
   skip_confirmation = each.value.skip_confirmation
   state             = each.value.state
+
+  lifecycle {
+    ignore_changes = [reset_password, force_random_password]
+  }
 }

--- a/user/variables.tf
+++ b/user/variables.tf
@@ -8,14 +8,14 @@ variable "users" {
     email    = string
 
     # optional
-    can_create_group  = optional(bool, false)
-    is_admin          = optional(bool, false)
-    is_external       = optional(bool, false)
-    note              = optional(string)
-    password          = optional(string)
-    projects_limit    = optional(number)
-    reset_password    = optional(bool)
-    skip_confirmation = optional(bool)
-    state             = optional(string)
+    can_create_group      = optional(bool, false)
+    is_admin              = optional(bool, false)
+    is_external           = optional(bool, false)
+    reset_password        = optional(bool, false)
+    force_random_password = optional(bool, true)
+    note                  = optional(string)
+    projects_limit        = optional(number)
+    skip_confirmation     = optional(bool)
+    state                 = optional(string)
   }))
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove ability to directly set user password
- add ability to use `force_random_password` for creating new users
- ignore changes to password fields to prevent deleting and recreating users (footgun protection)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

More secure, as we've eliminated the ability to insecurely set user passwords.
